### PR TITLE
TINY-9500: Writer.write api no longer adds a new line at the end of content inserted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Writer.write api no longer adds a new line at the end of the content inserted. #TINY-9500
+
 ## 6.0.1 - 2022-06-29
 
 ### Changed

--- a/src/main/ts/ephox/photon/Writer.ts
+++ b/src/main/ts/ephox/photon/Writer.ts
@@ -10,7 +10,7 @@ const write = (element: SugarElement<HTMLIFrameElement>, content: string): void 
   const doc = Reader.doc(element);
   const dom = doc.dom;
   dom.open('text/html', 'replace'); // Dont create new history https://bugzilla.mozilla.org/show_bug.cgi?id=1368869
-  dom.writeln(content);
+  dom.write(content);
   dom.close();
 };
 


### PR DESCRIPTION
Related Ticket: TINY-9500

Description of Changes:
* Writer.write api no longer adds a new line at the end of content inserted

Pre-checks:
* [x] Changelog entry added
* [x] ~package.json version bumped (if first change of new major/minor)~
* [x] ~Tests have been added (if applicable)~

Before merging:
* [x] Ensure internal dependencies are on appropriate versions
  * For stable releases, all dependencies must be stable
  * For release candidates, all dependencies must be release candidates or stable
